### PR TITLE
skip district select

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -56,7 +56,7 @@ export const districtSelectionGuard = (
   _from: RouteLocationNormalized
 ) => {
   const store = useElectionStore();
-  if (store.districts.length < 2) {
+  if (store.districts.length === 1) {
     const normalizedName = stringToNormalizedHyphenated(
       store.districts[0].name
     );

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -26,7 +26,7 @@ import SharePageVue from './routes/share/SharePage.vue';
 import AboutUsPageVue from './routes/about-us/AboutUsPage.vue';
 import AboutElectionsPageVue from './routes/about-elections/AboutElectionsPage.vue';
 import DataProtectionPageVue from './routes/data-protection/DataProtectionPage.vue';
-import { getDistrictCode } from './common/utils';
+import { getDistrictCode, stringToNormalizedHyphenated } from './common/utils';
 import VueSocialSharing from 'vue-social-sharing';
 
 const RESULT_QUERY_NAME = 'result';
@@ -36,7 +36,6 @@ export const questionGuard = (
   _from: RouteLocationNormalized
 ) => {
   const store = useElectionStore();
-
   //assign one if nr is missing
   if (!to.params.nr || to.params.nr === 'first') {
     to.params.nr = '1';
@@ -50,6 +49,24 @@ export const questionGuard = (
     console.warn(`Wrong question route ${to.path}`);
     return false;
   }
+};
+
+export const districtSelectionGuard = (
+  to: RouteLocationNormalized,
+  _from: RouteLocationNormalized
+) => {
+  const store = useElectionStore();
+  if (store.districts.length < 2) {
+    const normalizedName = stringToNormalizedHyphenated(
+      store.districts[0].name
+    );
+    const districtName = `${store.districts[0].district_code}-${normalizedName}`;
+    return {
+      name: appRoutes.guide.name,
+      params: { ...to.params, district: districtName },
+    };
+  }
+  return to;
 };
 
 const resultsProcessor = (
@@ -114,6 +131,7 @@ export const appRoutes = {
     meta: {
       title: 'Volební Kalkulačka',
     },
+    beforeEnter: districtSelectionGuard,
   },
   guide: {
     name: 'guide',

--- a/frontend/src/routes/district-selection/DistrictSelectionPage.vue
+++ b/frontend/src/routes/district-selection/DistrictSelectionPage.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { onBeforeRouteUpdate, useRoute, useRouter } from 'vue-router';
 import { mdiCloseCircleOutline } from '@mdi/js';
 
-import { appRoutes } from '@/main';
+import { appRoutes, districtSelectionGuard } from '@/main';
 import { useElectionStore } from '@/stores/electionStore';
 
 import type { Election } from '@/types/election';
@@ -29,6 +29,8 @@ import { stringToNormalizedHyphenated } from '@/common/utils';
 const router = useRouter();
 const route = useRoute();
 const electionStore = useElectionStore();
+
+onBeforeRouteUpdate(districtSelectionGuard);
 
 const election = electionStore.election as Election;
 const electionName = election.name;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(({ command, mode }) => {
       proxy: {
         '/data': {
           //target: 'http://127.0.0.1:5201/dev',
-          target: 'https://www.volebnikalkulacka.cz',
+          target: 'https://volebni-kalkulacka-2022.vercel.app/',
           changeOrigin: true,
           cookieDomainRewrite: { '*': '' },
           configure: (proxy) =>


### PR DESCRIPTION
The new route guard ensures that the district selection page is skipped if calculator has only one district