### PR TITLE
Generate questions-only data for presidential election 2023

### DIFF
--- a/data/kalkulacka/calculators.json
+++ b/data/kalkulacka/calculators.json
@@ -31,6 +31,21 @@
       "to": "2022-09-24T14:00:00"
     },
     {
+      "id": "prezidentske-2023-kolo-test",
+      "key": "prezidentske-2023-kolo-test",
+      "name": "Prezidentské volby 2023 - 1. kolo",
+      "description": "Letos se volí v prezidentských volbách.",
+      "instructions": {
+        "header": "Prezidentske - header",
+        "step_1_1": "",
+        "step_1_2": "",
+        "step_1_link": "",
+        "step_2_1": "Prezidentske - 2_2"
+      },
+      "from": "2022-01-13T14:00:00",
+      "to": "2022-01-14T14:00:00"
+    },
+    {
       "id": "prezidentske-2023-kolo-1",
       "key": "prezidentske-2023-kolo-1",
       "name": "Prezidentské volby 2023 - 1. kolo",
@@ -604,6 +619,15 @@
       "description": "Písek",
       "on_hp_from": "2022-09-03T14:00:00",
       "on_hp_to": "2022-09-24T14:00:00"
+    },
+    {
+      "election_id": "prezidentske-2023-kolo-test",
+      "district_code": "global",
+      "show_district_code": true,
+      "name": "global",
+      "description": "global",
+      "on_hp_from": "2022-09-03T14:00:00",
+      "on_hp_to": "2022-01-24T14:00:00"
     },
     {
       "election_id": "prezidentske-2023-kolo-1",

--- a/data/kalkulacka/prezidentske-2023-kolo-1/global.json
+++ b/data/kalkulacka/prezidentske-2023-kolo-1/global.json
@@ -21,28 +21,788 @@
   },
   "questions": [
     {
-      "id": "prezidentske-2023-kolo-1-global-q-4",
-      "name": "Rychlovlaky priorita",
-      "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
-      "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
+      "id": "prezidentske-2023-kolo-1-global-q-1",
+      "name": "Podmínky pro kandidaturu",
+      "title": "Hranice 50 tisíc podpisů, jež musí kandidáti na prezidenta získat od občanů, by se měla snížit. ",
+      "gist": "V ČR musí kandidáti získat podporu 50 tisíc občanů, jejichž podpisy pak ověřuje Ministerstvo vnitra. Např. v Rakousku pro kandidaturu stačí 5 tisíc ověřených podpisů od občanů.",
       "detail": "",
-      "tags": ["doprava"]
+      "tags": ["Prezidentské volby"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-2",
+      "name": "Podmínky pro kandidaturu",
+      "title": "Prezidentské kandidáty/ky by měli podpořit svými podpisy pouze občané, nikoli politici.",
+      "gist": "Kandidáti dnes musí dle zákona získat buď 50 tisíc podpisů od občanů, nebo najít podporu u 20 poslanců či 10 senátorů.",
+      "detail": "",
+      "tags": ["Prezidentské volby"]
     },
     {
       "id": "prezidentske-2023-kolo-1-global-q-3",
-      "name": "Celostátní referendum",
-      "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
-      "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
+      "name": "Kancelář prezidenta/ky - sídlo",
+      "title": "Mělo by se sídlo prezidenta/ky zachovat na Pražském hradě?",
+      "gist": "Pražský hrad je bývalé sídlo českých králů. Pro prezidenty není obvyklé, že úřadují v bývalých královských sídlech.",
       "detail": "",
-      "tags": ["demokracie"]
+      "tags": ["Kancelář prezidenta/ky"]
     },
     {
-      "id": "prezidentske-2023-kolo-1-global-q-1",
-      "name": "Zdanění prázdných bytů",
-      "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
-      "gist": "Zastánci zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
+      "id": "prezidentske-2023-kolo-1-global-q-4",
+      "name": "Orientace ČR ve světě",
+      "title": "Prezident/ka by se měl/a snažit, aby bylo Česko ve světě orientované na Západ.",
+      "gist": "",
       "detail": "",
-      "tags": ["bydlení"]
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-5",
+      "name": "Orientace ČR ve světě",
+      "title": "Prezident/ka by se měl/a snažit, aby bylo Česko ve vztahu ke světu co nejvíc neutrální.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-6",
+      "name": "Jmenování ministrů/ministryň",
+      "title": "Prezident/ka má mít právo odmítnout jmenovat ministra/yni podle svého uvážení.",
+      "gist": "Dle Ústavy jmenuje hlava státu ministry navržené premiérem. Výklady se liší: 1. prezident/ka musí návrhu na ministry vyhovět, 2. prezident může libovolně odmítnout jmenování člena vlády, neboť to Ústava výslovně nezakazuje.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-7",
+      "name": "Posilování obrany NATO",
+      "title": "Mělo by NATO v této době posilovat obranu ve svých členských zemích na východě Evropy?",
+      "gist": "Jde o země, které mají společnou hranici s Ruskem či Ukrajinou: Litva, Lotyško, Estonsko, Slovensko, Polsko, Maďarsko, Rumunsko, Norsko, případně výhledově Finsko.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky - politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-8",
+      "name": "Justice - Ústavní soud ČR",
+      "title": "Má prezident/ka nahrazovat předsedu Ústavního soudu před vypršením mandátu stávajícího předsedy?",
+      "gist": "Problematiku otevřel prezident Zeman záměrem jmenovat nového předsedu ÚS více než půl roku předtím, než skončí stávající předseda. Ústava podle něj žádné časové omezení nezná. Dle kritiků není možné rozhodovat dopředu o období, kdy už bude v úřadu jiná hlava státu.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-9",
+      "name": "Justice - Ústavní soud ČR",
+      "title": "Má mít prezident/ka možnost vybírat ústavní soudce bez souhlasu Senátu?",
+      "gist": "Prezident/ka podle stávající praxe navrhuje ústavní soudce a ty pak schvaluje Senát.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-10",
+      "name": "Pražský hrad - přístupnost veřejnosti",
+      "title": "Pražský hrad má být z většiny veřejně přístupný bez bezpečnostních kontrol.",
+      "gist": "Podle odpůrců kontrol by se měly chránit jen vnitřní prostory, kde se pohybuje prezident či vysocí státní činitelé. Komplex Pražského hradu je obrovský a atraktivní pro turisty, proto by ochrana neměla smysl. Policie však plošné kontroly hájila s tím, že Hrad je sídlo hlavy státu, což z něj dělá možný cíl útoku.",
+      "detail": "",
+      "tags": ["Pražský hrad"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-11",
+      "name": "Kancelář prezidenta/ky - platy úředníků",
+      "title": "Platy nejvyšších úředníků Kanceláře prezidenta by měly být veřejně známé.",
+      "gist": "Hradní kancelář se v době úřadování Václava Klause a Miloše Zemana zveřejňování platů vysokých úřadníků bránila. Soudy ale rozhodly v jejich neprospěch.",
+      "detail": "",
+      "tags": ["Kancelář prezidenta/ky"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-12",
+      "name": "Prezidentská imunita",
+      "title": "Měla by být možnost trestně stíhat prezidenta/ku i v době výkonu mandátu.",
+      "gist": "Prezidentská imunita trvá přesně od začátku do konce funkčního období, poté automaticky zaniká. Nestíhatelnost se týká trestných činů, přestupků apod. spáchaných před vznikem mandátu, i těch spáchaných během jeho výkonu. Po vypršení mandátu prezident/ka stíhán/a být může.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-13",
+      "name": "Prezidentská imunita",
+      "title": "Prezidentská imunita by měla trvat i po skončení mandátu.",
+      "gist": "Prezidentská imunita trvá přesně od začátku do konce funkčního období, poté automaticky zaniká. Nestíhatelnost se týká trestných činů, přestupků apod. spáchaných před vznikem mandátu, i těch spáchaných během jeho výkonu. Po vypršení mandátu prezident/ka stíhán/a být může.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-14",
+      "name": "Veto",
+      "title": "Prezident/ka by měl/a mít i nadále právo vetovat zákony.",
+      "gist": "Veto dovoluje hlavě státu vrátit Parlamentem schválený návrh zákona zpět do Poslanecké sněmovny. K přehlasování veta poslancům stačí, když jich pro zákon hlasuje většina (tj. 101 z celkového počtu 200).",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-15",
+      "name": "Udělování milostí",
+      "title": "Prezident/ka má mít možnost udělovat milosti i nadále bez omezení, podle své úvahy. ",
+      "gist": "Žádosti o milost shromažďuje Ministerstvo spravedlnosti; prezident Zeman určil, že mu je má předávat pouze v případech, kdy žadatel trpí závažnou chorobou.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-16",
+      "name": "Udělování milostí",
+      "title": "Je přijatelné, aby prezident/ka při udělování milostí obešel/la vlastní oficiální nařízení?",
+      "gist": "Žádosti o milost shromažďuje Ministerstvo spravedlnosti; prezident Zeman určil, že mu je má předávat pouze v případech, kdy žadatel trpí závažnou chorobou. Např. odsouzený ředitel Lesní správy Lány o milost vůbec nepožádal, prezident ministerstvo zcela obešel a milost mu udělil.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-17",
+      "name": "Pověření vítěze voleb",
+      "title": "Prezident/ka má po volbách pověřit jednáním o sestavení vlády vždy předsedu strany, která volby vyhrála.",
+      "gist": "V minulosti prezident V. Klaus nepověřil předsedu vítězné ČSSD J. Paroubka. Prezidenti Klaus (v r. 2004) a Zeman (v r. 2013) požadovali předem 101 podpisů poslanců před pověřením.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-18",
+      "name": "Podpisování zákonů",
+      "title": "Prezident/ka má podepsat všechny nové zákony, které nevetuje.",
+      "gist": "Dle Ústavy podepisuje zákony prezident, předseda Sněmovny a premiér. V minulosti se několikrát stalo, že prezident nepodepsal některé zákony a přitom je ani nevrátil parlamentu. Zákony tak začaly platit.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-19",
+      "name": "Podepisování mezinárodních smluv",
+      "title": "Prezident/ka má podepsat dojednané mezinárodní smlouvy bez ohledu na svůj osobní postoj.",
+      "gist": "Prezident dle Ústavy podepisuje mezinárodní smlouvy. V praxi Československa i ČR takové smlouvy vždy dojednávala vláda. Např. prezident Klaus dlouho odmítal podepsat tzv. Lisabonskou smlouvu, ale nakonec ji podepsal.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-20",
+      "name": "Odmítnutí jmenování soudců",
+      "title": "Prezident/ka má mít povinnost jmenovat navržené soudce/soudkyně.",
+      "gist": "Prezident/ka dle Ústavy jmenuje soudce/soudkyně a také jmenuje předsedy některých vyšších soudů. Prezidenti Klaus a Zeman v minulosti odmítli některé soudce jmenovat.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-21",
+      "name": "Role první dámy/prvního muže",
+      "title": "Má partner/ka prezidenta/ky aktivně zastávat roli první dámy/prvního muže? ",
+      "gist": "Např. Dagmar Havlová byla v roli první dámy aktivní, naopak Ivana Zemanová se drží v ústraní a na veřejnosti téměř nepůsobí.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-22",
+      "name": "Hlava státu s komunistickou minulostí",
+      "title": "Pro úřad prezidenta/ky je přijatelný i člověk, který byl za totality členem komunistické strany.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – morální kredit"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-23",
+      "name": "Hlava státu s trestní minulostí",
+      "title": "Je přijatelné, aby úřad prezidenta vykonával člověk v minulosti odsouzený za trestný čin?",
+      "gist": "V ČR může kandidovat a být zvolen člověk, který byl dříve pravomocně odsouzený. Ze zákona může být prezidentem/kou zvolen každý, kdo má: 1. státní občanství ČR, 2. věk alespoň 40 let, 3. aktivní volební právo. Než se stal prezidentem, byl v minulosti odsouzený např. Václav Havel.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – morální kredit"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-24",
+      "name": "Trestně stíhaný kandidát",
+      "title": "Je přijatelné, aby se hlavou státu stala osoba trestně stíhaná?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – morální kredit"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-25",
+      "name": "Majetkové daně",
+      "title": "Lidé s velkým majetkem by v ČR měli platit výrazně vyšší daně než doposud.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-26",
+      "name": "Lidé v exekucích",
+      "title": "Lidé, kteří se ocitli v exekuci, si mají pomoci sami.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-27",
+      "name": "Adopce dětí",
+      "title": "Možnost adoptovat děti by měly mít jenom heterosexuální páry.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-28",
+      "name": "Důchod a stáří",
+      "title": "Všichni senioři v ČR mají mít nárok žít důstojně bez chudoby.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-29",
+      "name": "Zdanění nadnárodních korporací",
+      "title": "Nadnárodní korporace, které vydělávají v ČR, zde mají danit své zisky.",
+      "gist": "Např. velké IT firmy často daní své zisky v zemích s nízkou či nulovou korporátní daní ze zisku. V Evropě tak mají nadnárodní korporace a velké technologické podniky centrály například v Irsku, Lucembursku nebo Nizozemsku.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-30",
+      "name": "Bydlení pro každého",
+      "title": "Stát / obce se mají postarat, aby měl každý kde bydlet.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-31",
+      "name": "Zrušení Senátu",
+      "title": "Podpořil/a byste zrušení Senátu?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-32",
+      "name": "Vystoupení z NATO",
+      "title": "ČR by měla vystoupit z NATO.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-33",
+      "name": "Vystoupení z EU",
+      "title": "ČR by měla vystoupit z Evropské unie.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-34",
+      "name": "Klima a oteplování",
+      "title": "Změny klimatu způsobuje hlavně lidstvo svou činností.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-35",
+      "name": "Média a sociální sítě",
+      "title": "Provozovatelé velkých sociálních sítí mají mít povinnost odstraňovat výhrůžky násilím.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-36",
+      "name": "Média a sociální sítě",
+      "title": "Provozovatelé velkých sociálních sítí mají mít povinnost odstraňovat  tzv. fake news (\"falešné zprávy\").",
+      "gist": "V Německu schválili zákon, který přikazuje provozovatelům, jako je Facebook, blokovat či smazat nezákonný obsah zveřejněný uživateli. Spadá tam mj. nacistická propaganda, podněcování k nenávisti či \"fake news\" (záměrně falešné zprávy).",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-37",
+      "name": "Pozvání na státní svátek",
+      "title": "Prezident/ka má na tradiční slavnost 28. října zvát všechny vysoké ústavní činitele bez výjimky.",
+      "gist": "Jde o pravidelné pozvánky na slavnost při předávání státních vyznamenání. Např. v roce 2022 prezident Zeman nepozval předsedkyni Sněmovny Markétu Pekarovou Adamovou a předsedu Senátu Miloše Vystrčila.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-38",
+      "name": "Ovlivňování justice",
+      "title": "Prezident/ka má ctít nezávislost soudů a nesmí nijak – ani doporučením – zasahovat do jejich rozhodování.",
+      "gist": "Bývalý předseda Nejvyššího správního soudu Josef Baxa uvedl, že mu Hrad dával opakovaně najevo, jak má jeho soud rozhodnout v některých kauzách. Podle Zemana nešlo o ovlivňování, ale pouze o „doporučení“ a tedy „vyjádření názoru“.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-39",
+      "name": "Změny klimatu",
+      "title": "Prezident/ka má podporovat aktivní řešení problémů spojených se změnami klimatu.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-40",
+      "name": "Držení zbraní",
+      "title": "V ČR by se mělo usnadnit legální držení zbraní.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-41",
+      "name": "Rada ČNB",
+      "title": "Na výběr členů Bankovní rady České národní banky mají být vypisována veřejná výběrová řízení.",
+      "gist": "Prezident dle Ústavy jmenuje členy Bankovní rady ČNB (skupinu 7 lidí, která ČNB řídí). Způsob jejich výběru je dnes zcela v jeho pravomoci. Dosavadní čeští prezidenti členy Bankovní rady vždy vybírali neveřejně.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-42",
+      "name": "Výuka romštiny",
+      "title": "Měla by se podporovat možnost výuky romštiny jako volitelného předmětu, pokud o ni bude mezi žáky zájem.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-43",
+      "name": "Zvýhodnění před důchodem",
+      "title": "Zaměstnávání lidí v předdůchodovém věku má být daňově zvýhodněno.",
+      "gist": "Lidé v předdůchodovém věku (zhruba od 55 let) jsou jednou ze skupin s vyšší nezaměstnaností. Jedna z možností, jak jejich zaměstnávání podpořit, jsou daňové úlevy.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-44",
+      "name": "Vyšší daň na alkohol",
+      "title": "Spotřební daň na alkohol by se měla zvýšit.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-45",
+      "name": "Očkování dobrovolné",
+      "title": "Očkování dětí má být jen dobrovolné.",
+      "gist": "V ČR je ze zákona povinné očkování proti některým onemocnění jako tetanus nebo obrna.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-46",
+      "name": "Asistovaná sebevražda",
+      "title": "Eutanazie (asistovaná sebevražda) má být v ČR legální.",
+      "gist": "Podle zastánců je ukončení vlastního života základním právem člověka, podle odpůrců je nemorální a hrozí zneužití. Asistovaná sebevražda není v ČR legální, je legální např. v Německu, ve Švýcarsku nebo v Belgii.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-47",
+      "name": "Zákaz interrupce",
+      "title": "Interrupce by měla být obecně zakázána.",
+      "gist": "Interrupce (umělé přerušení těhotenství) na žádost matky je v ČR možná stejně jako např. na Slovensku, v Rakousku či na Ukrajině. V Polsku je naopak zakázána. Podle zastánců je právo na potrat základním právem ženy, podle odpůrců je to vražda.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-48",
+      "name": "Vojenská pomoc Ukrajině",
+      "title": "ČR má zcela zastavit vojenskou pomoc Ukrajině.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-49",
+      "name": "Pokuty dle příjmů",
+      "title": "Pokuty za dopravní přestupky by měly odpovídat výši příjmů řidiče.",
+      "gist": "Ve Švýcarsku nebo ve Skandinávii se pokuty za dopravní přestupky určují v % z příjmů řidiče, aby trest byl citelný pro všechny řidiče obdobně.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-50",
+      "name": "Jaderné zdroje",
+      "title": "ČR má budovat další jaderné zdroje.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-51",
+      "name": "Znalosti prezidenta",
+      "title": "Prezident/ka má plynně hovořit aspoň jedním světovým jazykem.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-52",
+      "name": "Setkávání s tibetským vůdcem",
+      "title": "Má se prezident/ka oficiálně setkávat s duchovním vůdcem Tibetu (dalajlámou)?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-53",
+      "name": "Justice - jmenování soudců",
+      "title": "Hlava státu by měla jmenovat soudce a další osoby do jejich funkce bez ohledu na jejich věk.",
+      "gist": "Např. prezident Klaus odmítl jmenovat soudce kvůli jejich mladému věku.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-54",
+      "name": "Platy politiků a úředníků",
+      "title": "Stát by měl pravidelně zveřejňovat platy a odměny vrcholných politiků a vysokých státních úředníků.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-55",
+      "name": "Kvóty pro ženy",
+      "title": "Pro obsazování vysokých státních funkcí by měly být zavedeny kvóty pro ženy.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-56",
+      "name": "Prezentace postojů vlády",
+      "title": "Prezident/ka má prezentovat postoje vlády, i kdyby se neshodovaly s jeho/jejími osobními postoji.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-57",
+      "name": "Rozšíření pravomocí prezidenta",
+      "title": "Hlava státu ČR by měla mít oproti současnému stavu širší pravomoci.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-58",
+      "name": "Nové církevní stavby",
+      "title": "V ČR by měla být zakázána stavba jiných než křesťanských náboženských staveb.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-59",
+      "name": "Zavedení trestu smrti",
+      "title": "V ČR by měl být zaveden trest smrti.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-60",
+      "name": "Navrhování zákonů občany",
+      "title": "Občané by měli mít možnost předložit návrh zákona pomocí petice.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-61",
+      "name": "Elektronické volby",
+      "title": "Měla by být zavedena možnost volit po internetu.",
+      "gist": "Úspěšné elektronické hlasování může zrychlit sčítání hlasovacích lístků, snížit náklady na placení zaměstnanců počítajících hlasy a zajistit lepší přístupnost voleb pro například zdravotně znevýhodněné voliče.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-62",
+      "name": "Zavedení eura",
+      "title": "ČR má zavést společnou evropskou měnu (euro).",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-63",
+      "name": "Mezinárodní obchod a lidská práva",
+      "title": "ČR by měla usilovat o udržování obchodních vztahů i se zeměmi, které porušují lidská práva.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-64",
+      "name": "Politické názory",
+      "title": "Prezident/ka má prosazovat politické názory převažující u většinové části společnosti.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-65",
+      "name": "Lánská obora přístupná všem",
+      "title": "Lánská obora má být veřejně přístupná.",
+      "gist": "Oboru u zámku v Lánech spravuje Kancelář prezidenta republiky. Má rozlohu asi 30km2 a jen na malou výjimku je pro veřejnost nepřístupná.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-66",
+      "name": "Rada ČNB",
+      "title": "O výběru členů Bankovní rady České národní banky má i nadále rozhodovat pouze prezident/ka.",
+      "gist": "Prezident dle Ústavy jmenuje členy Bankovní rady ČNB (skupinu 7 lidí, která ČNB řídí). Způsob jejich výběru je dnes zcela v jeho pravomoci. Dosavadní čeští prezidenti členy Bankovní rady vždy vybírali neveřejně.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-67",
+      "name": "Ochrana životního prostředí",
+      "title": "ČR by měla více investovat do ochrany životního prostředí.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-68",
+      "name": "Upozorňování na porušování práv",
+      "title": "Prezident/ka by měl/a aktivně upozorňovat na porušování občanských nebo lidských práv v ČR i ve světě.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-69",
+      "name": "Jmenování prosorů",
+      "title": "Prezident/ka má mít právo odmítnout kandidát/ky na titul profesora navržené vysokými školami.",
+      "gist": "Návrh podává univerzitní vědecká rada ministerstvu, to ji postupuje prezidentovi. Miloš Zeman některé navržené odmítl jmenovat, ale soudy rozhodly ve prospěch kandidátů na profesory.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-70",
+      "name": "Podmínky pro kandidaturu",
+      "title": "Zákonodárci by měli podpořit vždy pouze jednoho kandidáta na prezidenta.",
+      "gist": "Současná právní úprava není jednoznačná, proto někteří poslanci a senátoři dávají podpisy více kandidátům najednou.",
+      "detail": "",
+      "tags": ["Prezidentské volby"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-71",
+      "name": "Vlajky na Hradě",
+      "title": "Souhlasím s tím, aby byla na Hradě vyvěšená vlajka Evropské unie.",
+      "gist": "Na prvním nádvoří Pražského hradu za prezidenta Zemana visely dvě vlajky – česká i evropská.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-72",
+      "name": "Vlajky na Hradě",
+      "title": "Souhlasím s tím, aby prezident/ka podporoval/a Ukrajinu vyvěšením vlajky na Hradě.",
+      "gist": "V březnu 2022 byly na znamení solidarity s Ukrajinou byly vztyčeny na stožáry na prvním nádvoří česká a ukrajinská vlajka.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-73",
+      "name": "Vlajky na Hradě",
+      "title": "Souhlasím s tím, aby prezident/ka podporoval/a Izrael vyvěšením vlajky na Hradě.",
+      "gist": "V roce 2021 byla na podporu Izraele na prvním hradním nádvoří vedle české vlajky vztyčena také izraelská. Nahradil jí vlajku Evropské unie, která dosud na Hradě vlála.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-74",
+      "name": "Odpovědnost za výkon pravomocí",
+      "title": "Prezident/ka by se měl/a zodpovídat za všechna svá rozhodnutí.",
+      "gist": "Prezident republiky není z výkonu své funkce odpovědný. Za rozhodnutí, které vyžaduje spolupodpis premiéra, odpovídá vláda. Z toho tedy vyplývá, že za výkon části pravomocí neodpovídá nikdo, pokud nenesou rysy velezrady nebo hrubého porušení Ústavy apod. Nelze jej zadržet, trestně stíhat ani stíhat pro přestupek nebo jiný správní delikt.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-75",
+      "name": "Prezident na zasedání vlády",
+      "title": "Prezident/ka by měl/a chodit pravidelně na jednání vlády.",
+      "gist": "Prezident má nyní možnost účastnit se zasedání vlády, vyžádat si od ní a od jejích členů informace a projednávat s vládou nebo s jejími členy záležitosti, které patří do jejich působnosti. Účast je nepovinná.",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-76",
+      "name": "Orientace ČR ve světě",
+      "title": "Prezident/ka by se měl/a snažit, aby bylo Česko ve světě orientované na Východ.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-77",
+      "name": "Zahraniční cesty prezidenta/ky",
+      "title": "Prezident/ka má na státních návštěvách připomínat dodržování lidských práv.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-78",
+      "name": "Úroveň psychologické a psychiatrické péče",
+      "title": "Měla by být pro stát priorita zlepšit úroveň psychologické a psychiatrické péče v ČR.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-79",
+      "name": "Bezplatná právní pomoc",
+      "title": "Stát by měl mít povinnost vytvořit systém bezplatné právní pomoci pro všechny.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-80",
+      "name": "Demokratická média",
+      "title": "Prezident/ka má komunikovat se všemi seriózními médii.",
+      "gist": "Za vyhýbání se řadě médií a slovní útoky na ně byl opakovaně kritizován prezident Zeman. Kritici poukazovali, že komunikuje jen s těmi, kdo mu nekladou nepříjemné otázky. Zastánci říkají, že si může vybírat, s kým se bude bavit, podle svého uvážení.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-81",
+      "name": "Veřejnoprávní média",
+      "title": "Česká veřejnoprávní média plní správně svoji funkci.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-82",
+      "name": "Obnovitelné zdroje",
+      "title": "Měla by současná energetická krize být impulsem k rychlejšímu přechodu k obnovitelným zdrojům výroby elektřiny?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-83",
+      "name": "Zákaz aut produkujících emise",
+      "title": "Souhlasíte s iniciativou EU zakázat výrobu nových aut produkujících emise po roce 2035?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-84",
+      "name": "Uhlíková neutralita",
+      "title": "Mělo by dosažení tzv. uhlíkové neutrality k roku 2050 být prioritou pro ČR i za cenu zhoršení ekonomických podmínek?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-85",
+      "name": "Evropská integrace",
+      "title": "Měly by spolu členské státy EU více spolupracovat a pokračovat v prohlubování integrace?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-86",
+      "name": "Korespondenční hlasování",
+      "title": "Měl by stát občanům v zahraničí umožnit účast ve volbách formou korespondenčního hlasování?",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-87",
+      "name": "Práce a rodina",
+      "title": "ČR by měla zlepšit podmínky pro ženy-matky, aby se mohly více uplatnit v práci.",
+      "gist": "ČR patří v Evropě k zemím, které mají velmi nízké zapojení žen na trhu práce po prvním i po druhém dítěti.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky – politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-88",
+      "name": "Spravedlnost pro všechny",
+      "title": "Souhlasím s tvrzením, že v Česku neplatí spravedlnost pro všechny stejně.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky - politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-89",
+      "name": "Legislativa",
+      "title": "Prezident/ka by měl/a mít pravomoc navrhovat zákony.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Pravomoci hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-90",
+      "name": "Rovné šance na vzdělání",
+      "title": "Prezident/ka by měl/a ze své pozice vyvíjet úsilí směrem k rovným šancím na vzdělání pro všechny děti.",
+      "gist": "Míra propadání a nedokončování základních škol se v různých částech Česka liší až desetinásobně. Řada studií vzdělávací neúspěšnost přisuzuje především Karlovarskému a Ústeckému kraji, zaostávají periferie bohatších krajů, Plzeňského, Jihočeského i části Pardubicka. V chudším Moravskoslezském kraji se některým částem naopak výrazně daří.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-91",
+      "name": "Život v informační společnosti",
+      "title": "Škola by měla především připravovat děti na život v informační společnosti.",
+      "gist": "Zastánci říkají, že školy by měly učit děti vyhledávat a pracovat s informacemi, kriticky myslet a umět svůj názor obhájit v diskuzi. Odpůrci namítají, že děti už tak tráví mnoho času u počítačů a mobilních telefonů a že by jim chyběly klasické znalosti.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky - politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-92",
+      "name": "Lidé v nouzi",
+      "title": "Prezident/ka by se ze své pozice měl/a zastávat lidí v tíživé ekonomické situaci.",
+      "gist": "Lidé v těžké ekonomické situaci mívají dlouhodobě nejhorší stav duševního zdraví – příznaky depresí a úzkostí během pandemie covid-19 narostly lidem s ekonomickými problémy i lidem v příjmové chudobě.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-93",
+      "name": "Boj s dezinformacemi",
+      "title": "Prezident/ka by ze své pozice měl/a vyvracet dezinformace.",
+      "gist": "Pokud se hlava státu dozví, že se ve veřejném prostoru šíří nepravdivé nebo zkreslené informace, měla by je veřejně uvádět na pravou míru.",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-94",
+      "name": "Šíření dezinformací",
+      "title": "Prezident/ka má mít povinnost ověřovat si informace, než je pronese na veřejnosti.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-95",
+      "name": "Práva menšin",
+      "title": "Prezident/ka by měl/a veřejně hájit práva menšin.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-96",
+      "name": "Klimatická změna",
+      "title": "Podporuji protesty studentů ve snaze přimět politiky, aby se vážně zabývali změnami klimatu.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky - politické postoje"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-97",
+      "name": "Energetická soběstačnost",
+      "title": "Prezident/ka by ze své pozice měl/a prosazovat energetickou soběstačnost ČR.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Výkon úřadu hlavy státu"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-q-98",
+      "name": "Cyklistika",
+      "title": "Prezident/ka by měl/a k cestám do úřadu využívat MHD nebo jízdní kolo, kdykoli je to možné.",
+      "gist": "Rakouský prezident je známý svými cestami hromadnou dopravou a nizozemský premiér jezdí stále častěji do práce na kole. Uvedl to na zasedání Světového ekonomického fóra (2019) s tím, že když to počasí dovolí, využívá k cestě do kanceláře své jízdní kolo.",
+      "detail": "",
+      "tags": ["Osobnost prezidenta/ky - politické postoje"]
     }
   ],
   "candidates": [
@@ -58,7 +818,8 @@
       "contacts": {
         "web": []
       },
-      "parties": []
+      "parties": [],
+      "motto": "Rozhoduji s klidem, chladnou hlavou a opírám se o zkušenosti"
     },
     {
       "id": "prezidentske-2023-kolo-1-global-c-904458",
@@ -86,7 +847,8 @@
       "contacts": {
         "web": []
       },
-      "parties": []
+      "parties": [],
+      "motto": "Změna, která nastartuje Česko. Ekonomka, profesorka, máma dvou dětí"
     },
     {
       "id": "prezidentske-2023-kolo-1-global-c-784509",
@@ -100,7 +862,8 @@
       "contacts": {
         "web": []
       },
-      "parties": []
+      "parties": [],
+      "motto": "Ochránce, vyjednavač, otevřený, vytrvalý, cílevědomý, připravený, odborně zdatný, zkušený, pracovitý..   "
     },
     {
       "id": "prezidentske-2023-kolo-1-global-c-879071",
@@ -114,7 +877,8 @@
       "contacts": {
         "web": []
       },
-      "parties": []
+      "parties": [],
+      "motto": "Nikdy neztrácím přesvědčení, že je šance měnit věci k lepšímu."
     },
     {
       "id": "prezidentske-2023-kolo-1-global-c-291038",
@@ -128,7 +892,8 @@
       "contacts": {
         "web": []
       },
-      "parties": []
+      "parties": [],
+      "motto": "Se mnou se na Pražský hrad vrátí důstojnost, aktivita a ochota pomáhat. Jsem připraven být váš prezident. "
     },
     {
       "id": "prezidentske-2023-kolo-1-global-c-800655",
@@ -143,7 +908,7 @@
         "web": []
       },
       "parties": [],
-      "motto": "SPD forever."
+      "motto": "Plním své sliby a nikdy neuhnu."
     },
     {
       "id": "prezidentske-2023-kolo-1-global-c-427663",
@@ -157,7 +922,8 @@
       "contacts": {
         "web": []
       },
-      "parties": []
+      "parties": [],
+      "motto": "Věřím, že zdravý rozum zvítězí."
     },
     {
       "id": "prezidentske-2023-kolo-1-global-c-497739",
@@ -172,48 +938,4914 @@
         "web": []
       },
       "parties": [],
-      "motto": "Jsem boží."
+      "motto": "Obyčejný muž pro neobyčejnou zemi "
     }
   ],
   "answers": [
     {
-      "id": "prezidentske-2023-kolo-1-global-a-497739-4",
-      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
-      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "id": "prezidentske-2023-kolo-1-global-a-784509-1",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-1",
       "answer": "yes",
-      "comment": "Yes, please."
+      "comment": "Umožnit i elektronicky"
     },
     {
-      "id": "prezidentske-2023-kolo-1-global-a-497739-3",
-      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "id": "prezidentske-2023-kolo-1-global-a-784509-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
       "question_id": "prezidentske-2023-kolo-1-global-q-3",
       "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no",
+      "comment": "Otázka je v rozporu se zákonem, který je dostačující."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no",
+      "comment": "Pokud se prezident zavázal k něčemu nad rámec zákona, měl by to dodržovat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "yes",
+      "comment": "Podmiňuji to debatou o celém daňové systému."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "yes",
+      "comment": "Zákon by ale měl definovat, co je a co není fake news a kdo to bude posuzovat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "no",
+      "comment": "Stávající úprava je dostačující."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "no",
+      "comment": "Musí být definováno zákonem."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "no",
+      "comment": "Shodný názor by neměl být automatický, ale měly by k tomu obě strany směřovat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "yes",
+      "comment": "Musí to být však ošetřeno zákonem, včetně vyloučení oblastí, kde to nelze, např. obrana a bezpečnost."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "yes",
+      "comment": "Rozhodně ne v současné době."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "yes",
+      "comment": "Ale musí být podmíněno mezinárodními sankcemi."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes",
+      "comment": "Ano, ale pro oba rodiče."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-784509-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-784509",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-1",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-1",
+      "answer": "no",
+      "comment": "Měla by se ale zavést možnost odeslat ověřený podpis pod petici kandidáta i elektronickou cestou, tak aby sběr podpisů neprobíhal pouze fyzicky."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
+      "answer": "no",
+      "comment": "Protože politici jsou volení zástupci lidu, hlavní náplní jejich práce by mělo být hájit zájem svých voličů, s tím souvisí také možnost navrhovat kandidáty do ústavních funkcí včetně hlavy státu."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "answer": "yes",
+      "comment": "Protože Pražský hrad je symbol státnosti a administrativní zázemí je tam k dispozici, jeho přesun by byl finančně nákladný. Prezident by ale měl většinu práce vykonávat v podhradí a být mezi lidmi. Zároveň je třeba Pražský hrad otevřít veřejnosti."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "yes",
+      "comment": "Západem rozumím společenství demokratických zemí, a to i těch které leží v Asii a Pacifiku, například Austrálie či Jižní Korea."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "no",
+      "comment": "Protože nejsme neutrální zemí, jsme zemí demokratickou, tak je v pořádku, abychom se otevřeně hlásili ke straně demokracie, svobody a lidských práv."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "no",
+      "comment": "Mělo by zůstat zachováno, co je dnes psáno v Ústavě. Za složení a výkon vlády odpovídá premiér. Pouze v případě, kdy má prezident velmi závažné důvody, proč se domnívá, že je daná osoba nezpůsobilá k výkonu funkce, a na tomto názoru panuje i široká společenská shoda, může ministra odmítnout jmenovat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no",
+      "comment": "Je v pořádku, aby o takto důležitých ústavních činitelích spolurozhodovala horní komora Parlamentu ČR."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes",
+      "comment": "Ale míra a rozsah bezpečnostních kontrol by měla odpovídat aktuální bezpečnostní situaci, pokud jsou vyhodnocena zvýšená rizika, je potřeba bezpečnostní opatření zpřísnit."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "no",
+      "comment": "Kdyby byl trestně stíhán v průběhu mandátu, nemohl by plnohodnotně vykonávat funkci hlavy státu."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes",
+      "comment": "Tuto pravomoc by měl ale využívat pouze výjimečně, své připomínky k zákonům a rozpočtu by měl uplatňovat v průběhu jejich tvorby."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "yes",
+      "comment": "Ale měl by k nim přistupovat pouze ve výjimečných případech, zejména z humanitárních důvodů."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "no",
+      "comment": "Důležitá je schopnost designovaného premiéra sestavit stabilní vládu s důvěrou poslanecké sněmovny, tedy opřenou o alespoň 101 hlasů poslanců."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "no",
+      "comment": "Prezident je součástí vyjednávacího procesu, takže jeho postoj by měl být zohledněn už před samotným podpisem. Pokud zohledněn není a prezident má závažné důvody s ratifikací nesouhlasit, měl by mít v krajní situaci možnost smlouvu nepodepsat v zájmu ochrany strategických zájmů ČR."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "no",
+      "comment": "Měl by postupovat podle znění Ústavy a zákonů - odpovědnost navrhovat soudce má ministerstvo spravedlnosti a prezident je následně jmenuje. Pouze v krajním případě, kdy kandidát nesplňuje elementární předpoklady pro výkon funkce, by měl mít prezident možnost vyjádřit pochybnosti."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "yes",
+      "comment": "Samotné členství by nemělo být diskvalifikující, podstatné je, co člověk po celý život dělal v ve prospěch České republiky."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "yes",
+      "comment": "Protože takovým trestným činem může být například dopravní nehoda, pokud si trest již odpykal, není důvod se na kandidáta koukat jako na zvrhlíka."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "no",
+      "comment": "Zákon vychází z presumpce neviny, takže tato možnost existuje, ale prezident by měl být nezpochybnitelnou morální autoritou."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "no",
+      "comment": "Je v pořádku, aby se bohatší lidé více podíleli na solidaritě. Progresivní daň z příjmu ale již existuje a její případné zvýšení by mělo být součástí transformace celého daňového systému."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no",
+      "comment": "V individuálních případech, kdy se dlužníci neocitli v exekuci vlastní vinou, by měli mít možnost, aby jim společnost pomohla."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "no",
+      "comment": "Protože by měl být rozhodující zájem dítěte. Když si dám na misky vah kvalitu života dítěte bez rodiny v dětském domově a kvalitu života dítěte ve stabilním prostředí s milujícími rodiči, tak pro mě nehraje roli, jakého jsou pohlaví."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "no",
+      "comment": "Důchodový systém musí zaručovat důstojné stáří, ale výše důchodu musí zohledňovat i přístup člověk k práci v jeho aktivních letech."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "no",
+      "comment": "Stát by měl poskytnout asistenci lidem, kde ji nejvíce potřebují, ale bydlení nelze garantovat jako nárok všem."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "no",
+      "comment": "Senát mnohokrát prokázal svoji funkci jako pojistka demokratického systému."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "no",
+      "comment": "Měli by mít ale povinnost odstraňovat dezinformace v jednoznačných a společensky závažných případech."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "no",
+      "comment": "Stávající úprava je dostačující."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "no",
+      "comment": "Ale celý proces by měl být maximálně transparentní, aby veřejnost znala kdo a podle jakých kritérií je jmenován."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "yes",
+      "comment": "Je to výraz svobodné volby"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "yes",
+      "comment": "Je pravděpodobné, že se bude prodlužovat věk odchodu do důchodu, zaměstnavatelé by měli být motivováni dávat práci i lidem jejichž perspektiva uplatnění je omezená."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "no",
+      "comment": "Výše jednotlivých daní by se měla měnit až v rámci komplexní daňové reformy s ohledem na to, jaké změny přinesou největší přínos pro veřejné finance a zároveň nejméně dopadnou na nejslabší skupiny."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "yes",
+      "comment": "Stejně jako bych každému rád dopřál právo na důstojný život, tak myslím, že by každý měl mít právo na důstojný odchod. Alespoň já bych ho rád měl. Jsou případy, kdy člověk trpí, nemá vůli jít dál, ale my uměle prodlužujeme jeho utrpení. V některých zemích, například ve Švýcarsku, už toto právo existuje. Myslím, že bychom ho lidem neměli odpírat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "yes",
+      "comment": "Protože u závažných dopravních přestupků, zejména když řidič svým jednáním ohrožuje své okolí, by pokuta měla mít výchovný efekt a být citelná i pro řidiče s vysokými příjmy."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "yes",
+      "comment": "Prezident se může setkávat s kýmkoli, kdo hodnotově odpovídá našemu vidění světa."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "no",
+      "comment": "Je třeba zohledňovat zejména získané zkušenosti v oboru, v mladém věku nemusí být dostatečné."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no",
+      "comment": "Rozhodující by měla zkušenost, pohlaví není kvalifikace, je však potřeba nastavit podmínky tak, aby pohlaví nebyla diskvalifikace."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "no",
+      "comment": "Ve vnitřní politice není nutné, aby měl prezident shodný názor s vládou, pokud jde o zahraniční politiku, měla by být koordinovaná se všemi ústavními činiteli."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "yes",
+      "comment": "Ve vazbě na podstatnou digitalizaci celé státní správy a vytvoření zaručených mechanismů, aby nedocházelo k volebním podvodům."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "yes",
+      "comment": "Jako občan jsem pro, česká ekonomika je již nyní úzce provázaná s eurozónou a přijetí eura nám dá možnosti podílet se na rozhodování o společné měnové politice. Toto rozhodnutí by ale měla vláda udělat až v okamžiku, kdy to pro ČR bude ekonomicky i politicky výhodné."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "yes",
+      "comment": "Na prosazování lidských práv nesmíme rezignovat a jejich dodržování je potřeba prosazovat. Pokud je ale obchodování nutné s ohledem na závislost na nějaké surovině či technologii, musíme takové vztahy udržovat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "yes",
+      "comment": "Ve smyslu toho, že demokracie je vládou většiny."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "no",
+      "comment": "Určitá forma spolurozhodování například se Senátem by byla na místě, protože jde o důležité funkce, na kterých by měla existovat širší shoda."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "no",
+      "comment": "Měl by postupovat podle znění Ústavy a zákonů - odpovědnost navrhovat profesory mají vysoké školy a prezident je následně jmenuje. Pouze v krajním případě, kdy kandidát nesplňuje elementární předpoklady, měl by mít prezident možnost vyjádřit pochybnosti."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "no",
+      "comment": "Podle Ústavy čl. 54 je ze své funkce neodpovědný."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "no",
+      "comment": "Závisí to na důležitosti a urgenci projednávaných zákonů či opatření"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "yes",
+      "comment": "Ale stále je co zlepšovat :)"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "yes",
+      "comment": "Vláda ale musí zajistit odpovídající mix energetických zdrojů, není to jen o těch obnovitelných."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "yes",
+      "comment": "Na základě důkladných analýz proveditelnosti"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "yes",
+      "comment": "Když budeme neustále zdůrazňovat jen ekonomické zájmy, nikdy se v ochraně klimatu nepohneme kupředu. Dopady by ale měly být rovnoměrné pro všechny země Evropy a světa."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "yes",
+      "comment": "Tempem přijatelným pro všechny členské země"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes",
+      "comment": "Tak jako každá veřejná autorita"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes",
+      "comment": "Se zohledněním toho, co je realizovatelné v praxi, by měla být ČR energeticky co nejvíce nezávislá."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-935631-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-935631",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-1",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "yes",
+      "comment": "Jsme součástí západního světa jak je nyní vnímán."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "no",
+      "comment": "Jsme součástí EU a NATO, nejsme neutrální země"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "no",
+      "comment": "Prezident může odmítnou návrh výhradně na základě rozporu kandidáta se zákonem"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "dont_know",
+      "comment": "Je to otázka pro ústavní právo - ústavní soud"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no",
+      "comment": "Prezident by měl být konzistentní ve svých názorech, milost je jeho absolutní pravomoc"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "yes",
+      "comment": "Proces ratifikace mezinárodních smluv je dán zákonem.  Jde o spolupráci parlamentu a prezidenta. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "no",
+      "comment": "Prezident může odmítnou návrh výhradně na základě rozporu kandidáta se zákonem."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes",
+      "comment": "Je to ale na jejím uvážení."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "yes",
+      "comment": "O vině/nevině rozhodují soudy nikoliv státní zastupitelství."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "yes",
+      "comment": "Čeká nás změna daňového systému. Progresivnímu zdanění se pravděpodobně nevyhneme."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no",
+      "comment": "Dluhy se musí platit, ale jsou různé důvody jak se lidé do nich dostali. Například exekuce nezletilých jsou nepřijatelné a stát musí zasáhnout."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "no",
+      "comment": "Adopce dětí je velmi delikátní proces a vždy závisí na individuálním posouzení."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "no",
+      "comment": "Ale mají pomoci těm v nouzi."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "yes",
+      "comment": "Napomáháme tomu co se děje i bez nás."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "yes",
+      "comment": "Měli by spadat pod stejná pravidla jako ostatní média, otázkou je kdo posuzuje co je a co není fake news."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "dont_know",
+      "comment": "Je nutná celospolečenská debata a musí být připravena silná a transparentní pravidla aby nedošlo k zneužití."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "no",
+      "comment": "Prezident má dodržovat zákony a pravidla. Například soudcem Ústavního soudu může být jmenován bezúhonný občan, který je volitelný do Senátu (věk nad 40 let), má vysokoškolské právnické vzdělání a byl nejméně deset let činný v právnickém povolání."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "no",
+      "comment": "Ve výjimečných a zásadních případech, není-li možná dohoda, musí prezident jednat podle svého svědomí a prezidentského slibu."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "yes",
+      "comment": "Například právo navrhovat zákony."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "no",
+      "comment": "Máme systém zastupitelské demokracie, mohou se obrátit na své poslance."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "yes",
+      "comment": "Jakmile splníme kritéria."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "yes",
+      "comment": "Většina zemí na světě nejsou demokracie. Pokud konkrétní obchodní vztahy slouží k udržení otevřeného světa, pak není důvod jim bránit. Je třeba využít všechny možnosti k udržení propojeného světa. Současně si samozřejmě musíme dávat pozor, abychom se nestali ve strategických surovinách či zboží závislí na zemích, které toho mohou zneužít."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "yes",
+      "comment": "Prezident je volen většinou společnosti a reprezentuje tedy její názory. Jeho povinností je ale dle Ústavy bránit práva všech občanů."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "no",
+      "comment": "Veřejnoprávní média jsou důležitou součástí svobodné společnosti. Jejich současný model ale neopovídá měnícímu se mediálnímu prostředí ani formou, ani obsahem.  "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "yes",
+      "comment": "Prezident nesmí lhát. Jeho rolí není být propagandistou vlády či opozice. Setká-li se s nepravdou či manipulací z jakékoliv strany, má o tom veřejnost informovat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "yes",
+      "comment": "Prezident má hájit zájmy všech občanů ČR."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "yes",
+      "comment": "Každý má právo vyslovit svůj názor i případným protestem."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-427663-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-427663",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "no",
+      "comment": "Já obvykle již cestou pracuji a to by na kole nebo v MHD bylo obtížné."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-1",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "dont_know",
+      "comment": "Jak v čem. V ekonomické diplomacii by měla platit politika všech azimutů."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "yes",
+      "comment": "S ohledem na náš export"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "no",
+      "comment": "Proti komu?"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "no",
+      "comment": "přesáhl by tím svůj časový mandát"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no",
+      "comment": "Ústava to nedovoluje"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "no",
+      "comment": "Nepodepsáním může vyjádřit svůj politický či morální postoj"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "no",
+      "comment": "viz komentář k předchozí otázce"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "dont_know",
+      "comment": "Záleží na tom kdy, jak dlouho a proč."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "yes",
+      "comment": "Záleží na tom za jaký a kdy. Jako příklad může sloužit Václav Havel"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "yes",
+      "comment": "V případě, když NATO nebude dodržovat článek 1 Severoatlantické smlouvy"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "no",
+      "comment": "Neexistuje právní definice fake news"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "no",
+      "comment": "nelze narušovat rovnost občanů před zákonem"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "no",
+      "comment": "Proč pouze s ním? jsme snad většinově budhisté?"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "no",
+      "comment": "příliš nízký věk de facto vylučuje předepsanou praxi"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no",
+      "comment": "Ovšem podmínil bych to reciprocitou"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "yes",
+      "comment": "ale musí vést společnost k dialogu s menšinami"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "no",
+      "comment": "jde o oboru, to některé aktivity vylučuje"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "yes",
+      "comment": "Ale musí k tomu mít závažné důvody"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "yes",
+      "comment": "To je snad logické"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "yes",
+      "comment": "Ovšem harmonogram pravidelnosti si stanovuje sám"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "yes",
+      "comment": "Ale všude, bez dvojího metru."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes",
+      "comment": "Se všemi médii"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "no",
+      "comment": "obnovitelné zdroje jsou zdroji občasnými"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "no",
+      "comment": "Více Evropy znamená méně demokracie"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "yes",
+      "comment": "zejména ty mainstreamové"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-800655-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "no",
+      "comment": "Peleton prezidenta a ochranky by zablokoval dopravu"
     },
     {
       "id": "prezidentske-2023-kolo-1-global-a-497739-1",
       "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
       "question_id": "prezidentske-2023-kolo-1-global-q-1",
       "answer": "yes",
-      "comment": "Test only"
+      "comment": "Celý systém by se měl změnit. Jednou z možných cest je sběr menšího množství podpisů, ale rovnou ověřených (CzechPoint, Datové schránky). "
     },
     {
-      "id": "prezidentske-2023-kolo-1-global-a-800655-4",
-      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
-      "question_id": "prezidentske-2023-kolo-1-global-q-4",
-      "answer": "dont_know"
-    },
-    {
-      "id": "prezidentske-2023-kolo-1-global-a-800655-3",
-      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
-      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "id": "prezidentske-2023-kolo-1-global-a-497739-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
       "answer": "no"
     },
     {
-      "id": "prezidentske-2023-kolo-1-global-a-800655-1",
-      "candidate_id": "prezidentske-2023-kolo-1-global-c-800655",
+      "id": "prezidentske-2023-kolo-1-global-a-497739-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "answer": "yes",
+      "comment": "Je to vazba na českou historii a tradici naší státnosti. Bydlel bych ale jinde. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "no",
+      "comment": "Ve střední Evropě nelze být neutrální a naše historie to mnohokrát ukázala. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "yes",
+      "comment": "Současná úprava Ústavy by měla být zachována. K odmítnutí by ale měly vést závažné důvody, nikoli svévole. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "no",
+      "comment": "Současná úprava je v pořádku - prezidenta lze stíhat po vypršení mandátu. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "yes",
+      "comment": "Je to do jisté míry pozůstatek z feudálních dob, ale když tam je, pak ji takto nechme. Je to individuální akt. Že by si jej měl ale prezident veřejně obhájit považuji za zásadní. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "no",
+      "comment": "Je to obdobná situace jako u jmenování ministrů. Prezident disponuje informacemi např. od tajných služeb. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "dont_know"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "yes",
+      "comment": "TČ může být i např. dopravní nehoda. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "no",
+      "comment": "Já osobně to za přijatelné nepovažuji, ale zákonem bych to neomezoval. Současnou úpravu Ústavy považuji za dostatečnou. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no",
+      "comment": "Jde o systémový problém, který už vyžaduje systémové řešení. Řada lidí v exekuci navíc není sama schopna si pomoci. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "yes",
+      "comment": "S výhradami, jako jsou např. lidé, kteří strávili většinu života ve vězení. Má odpověď se tak vztahuje k lidem, kteří normálně celý život pracovali. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "dont_know",
+      "comment": "Mají se snažit samostatně stavět bydlení, podporovat družstva, neblokovat zbytečně novou výstavbu apod. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "no",
+      "comment": "K NATO nemáme žádnou bezpečnostní alternativu. A stav, kdy jsme téměř sami, jsme zažili v letech 1918-1938, výsledek je obecně znám. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "no",
+      "comment": "Jde o to, že pak se ona síť nebo stát stanou arbitrem pravdy, a to je možná nebezpečnější, než šíření nesmyslů. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes",
+      "comment": "Stejně jako se má zapojovat do řešení řady dalších celospolečenských otázek. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "no",
+      "comment": "Není to potřeba. Současná úprava je velmi dobrá - dává zákonadbalým občanům možnost držet a nosit zbraně, ale současně omezuje nabytí rizikovými lidmi. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "dont_know"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "dont_know",
+      "comment": "Státní zásahy do trhu práce (např. vyšší ochrana některých skupin) vedou mnohdy v praxi k opačným efektům. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "no",
+      "comment": "U prověřených vakcín na nejzávažnější nemoci - důvodem je vznik kolektivní imunity, který chrání ty, kdo se očkovat nemohou. Nicméně u zdůvodněných případů je už teď možnost očkování odmítnout. Takto to vnímám v pořádku. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "dont_know",
+      "comment": "Obecně ji považuji za přijatelnou, obrovským problémem je možné zneužití. Podepsal bych jen zákon, který by toto řešil opravdu velmi precizně a toto riziko elimiminoval. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "dont_know",
+      "comment": "Zahraniční politiku určuje primárně vláda a prezident má danou linii dodržovat. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no",
+      "comment": "Správně je vytvářet podmínky, v nichž se budou moci ženy naplno věnovat práci, kterou si vyberou. Ale jakýkoli výběr, který není postaven na schopnostech, bude nespravedlivý. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "no",
+      "comment": "Shoda má být zejména u zahraniční politiky. V domácí má naopak přímo volený prezident být protivahou vlády. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "no",
+      "comment": "Současné pravomoci jsou odpovídající. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "no",
+      "comment": "Volby musí být přímo, rovné a tajné. Online volba nesplňuje téměř nic z toho. Plus by stát disponoval údajem o tom, jak člověk volil, což je nesmírně nebezpečné. Dalším rozměrem je vznik nedůvěry k systému (viz USA). "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "no",
+      "comment": "Nyní ne. Jednak bychom přišli o vlastní měnovou politiku, jednak i v rámci měnové unie přibývá států, které neplní Maastrichtstká kritéria (větší schodky, velké celkové zadlužení)."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "yes",
+      "comment": "Většina zemí světa má nižší standardy lidských práv než západní svět. Spíš se snažme ve vzájemném kontaktu tamní poměry zlepšovat. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "no",
+      "comment": "Prezident se má chovat v souladu s programem, s nímž kandidoval. Ve funkci se pak má zastávat lidí obecně, být protivahou vládě (ať pravicové, nebo levicové). "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "dont_know",
+      "comment": "Prezident by měl realizovat zahraniční politiku v souladu s vládou, a primárně je to vláda, kdo ji stanovuje. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "yes",
+      "comment": "Ve výjimečných a zdůvodněných případech (např. na základě informací od tajných služeb). Nesmí jít o svévoli. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "no",
+      "comment": "Jde o symbol české státnosti, výhradně. Další vlajky tu mohou zavlát ad hoc např. při významné státní návštěvě, jinak ne. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "no",
+      "comment": "Jde o symbol české státnosti, výhradně. Další vlajky tu mohou zavlát ad hoc např. při významné státní návštěvě, jinak ne. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "no",
+      "comment": "Jde o symbol české státnosti, výhradně. Další vlajky tu mohou zavlát ad hoc např. při významné státní návštěvě, jinak ne. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "dont_know",
+      "comment": "Tato otázka je pro mne obtížně srozumitelná. Z výkonu své funkce prezident odpovědný (v trestně-právním smyslu) není, a to je v pořádku. Pokud máte na mysli zodpovídat se veřejnosti, svá rozhodnutí vysvětlit a obhájit, pak by byla odpověď ano. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "no",
+      "comment": "Zahraniční politiku určuje primárně vláda. Já osobně bych se o připomínku lidských práv, kde to lze, je to vhodné a dává to smysl, snažil. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes",
+      "comment": "Její zanedbání ohrožuje pak celou společnost, viz USA. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "dont_know"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "dont_know"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "yes",
+      "comment": "Pro účely této odpovědi sem řadím i jádro. Pokud by to byly jen OZE, pak je to v současné situaci nerealistické. Cílem je mít STABILNÍ, NÍZKOEMISNÍ a nákladově přijatelné zdroje. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "no",
+      "comment": "Otázku vnímám jako směr federalizace, zrušení veta apod. - a s tím nesouhlasím. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "dont_know",
+      "comment": "Mám obecně výhrady k hlasování na dálku - zejména proto, že neodpovídá požadavkům na přímé, rovné a tajné volby (v tomto případě není zajištěna jistota, že šlo o přímou a tajnou volbu). Nicméně dobrým nastavením by to šlo alespoň zčásti omezit. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes",
+      "comment": "Ale stejně tak i pro jednopřímové rodiny, kde se žena rozhodne více věnovat naopak domácnosti a dětem. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "no",
+      "comment": "Prezident není a nemá být nástrojem zákonodárné moci. Pokud už chce něco podobného iniciovat, může inspirovat poslance či senátory. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "dont_know",
+      "comment": "Prezident by měl s lidmi mluvit otevřeně a srozumitelně o celospolečenských tématech. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes",
+      "comment": "Zákonnou povinnost ne, ale morální ano, protože jeho slova mají velkou váhu a velký dopad. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "dont_know",
+      "comment": "Prezident by měl veřejně hájit práva všech občanů a dalších lidí žijících v této zemi, tedy včetně příslušníků menšin. Z toho pohledu ano. Pokud je tím míněno \"jen práva menšin\", pak je odpověď logicky ne. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-497739-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "no",
+      "comment": "Občas klidně, ale pokud se potřebujete pružně přemisťovat po Praze a ČR, pak to na kole obvykle moc nejde.  "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-1",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "answer": "yes",
+      "comment": "Prezident by měl mít na Hradě kancelář, neměl by tam ale bydlet. Naopak měl by udělat maximum, aby se Hrad otevřel lidem a stal se významnou kulturní a společenskou křižovatkou."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "no",
+      "comment": "Toho, kdo má největší šanci sestavit stabilní vládu."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "yes",
+      "comment": "ANO, pokud tyto postoje vlády neohrožují demokracii, bezpečnost státu a lidská práva"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "no",
+      "comment": "Pravidelně ne"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "dont_know"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-728980-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-728980",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-1",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "yes",
+      "comment": "Pouze v závažných případech, např. při střetu zájmů nebo trestním stíhání."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "no",
+      "comment": "Trestní stíhání by mohlo být politicky zneužíváno."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "no",
+      "comment": "Současná legislativa regulující držení zbraní je dostačující."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes",
+      "comment": "Český stát je v perspektivě 20 let schopen postavit pouze náhradu za JA Dukovany."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "yes",
+      "comment": "Prezident má respektovat postoje vlády. Mohou ale nastat extrémní situace, kdy prezident musí odmítnout postoje vlády. Například pokud by bylo ohroženo demokratické zřízení státu nebo porušována Ústava. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "no",
+      "comment": "Přestože jsem podporovatelem digitalizace státu, elektronické volby mají vážná úskalí, proto se kloním ke klasickému způsobu."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-879071-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-879071",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-1",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
       "question_id": "prezidentske-2023-kolo-1-global-q-1",
       "answer": "no",
-      "comment": "SPD, SPD, co si počnem bez tebe."
+      "comment": "Volební zákon bude třeba celý upřesnit. Současná podoba vytváří příliš mnoho nejistoty. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-2",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-3",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-3",
+      "answer": "yes",
+      "comment": "KPR a její úředníci by se ale výhledově mohli přestěhovat do podhradí. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-4",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-4",
+      "answer": "yes",
+      "comment": "Samozřejmě, nevidím alternativu. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-5",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-5",
+      "answer": "no",
+      "comment": "Nejsme neutrální země. Naše ústava má v sobě silný hodnotový náboj. Dělali bychom chybu, pokud bychom na to nebrali ohled i v zahraniční politice. Přišli bychom o spojence. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-6",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-7",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-7",
+      "answer": "yes",
+      "comment": "Nemáme na výběr. Součástí naší obrany je, že budeme věrohodně připraveni se bránit. A to bez vojenských jednotek na východní hranici NATO nepůjde. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-8",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-8",
+      "answer": "no",
+      "comment": "Bylo by to v hrubém rozporu s ústavou ČR. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-9",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-10",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-11",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-12",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-13",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-14",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-15",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-16",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-17",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-17",
+      "answer": "no",
+      "comment": "Prezident může usilovat o to nalézt alternativní variantu, například pověřit šéfa seskupení politických stran koalice, z nichž žádná sice nebude vítězem, ale dohromady dají v parlamentu většinu. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-18",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-19",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-20",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-21",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-22",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-23",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-23",
+      "answer": "no",
+      "comment": "Případ Václava Havla byl jedinou možnou výjimkou."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-24",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-25",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-25",
+      "answer": "yes",
+      "comment": "V České republice budeme muset opravit daňový systém tak, aby příjmy státního rozpočtu byly na úrovni výdajů. A zdanění bohatých je jednou z úprav, které bude na místě připravit.  "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-26",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-27",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-27",
+      "answer": "no",
+      "comment": "Ale jako prezident bych respektoval vůli parlamentu a podobný zákon podepsal."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-28",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-29",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-29",
+      "answer": "yes",
+      "comment": "Zdanění velkých nadnárodních korporací je velký úkol nejen pro ČR. Jedná se o téma, jemuž se aktivně věnuje např. OECD, odkud bychom si mohli vzít inspiraci. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-30",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-31",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-32",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-32",
+      "answer": "no",
+      "comment": "V době, kdy se do Evropy vrátila válka, by podobný krok byl naprosto vedle. Trend je dnes právě opačný, o čemž svědčí zájem dosud neutrálního Finska a Švédska o vstup do NATO. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-33",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-33",
+      "answer": "no",
+      "comment": "Ne, naším úkolem je v EU se umět lépe prosadit.  "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-34",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-35",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-36",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-37",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-38",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-39",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-40",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-41",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-42",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-43",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-43",
+      "answer": "yes",
+      "comment": "Na trhu práce existuje jistá diskriminace spojená s věkem pracovníka. Lidé v předdůchodovém věku nejsou viděni jako perspektivní, přestože jejich zkušenosti můžou být velkým přínosem. Daňové zvýhodnění by mohlo být jednou z cest, jak je udržet v zaměstnání.  "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-44",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-45",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-46",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-46",
+      "answer": "no",
+      "comment": "Obával bych se zneužití. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-47",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-48",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-48",
+      "answer": "no",
+      "comment": "Na Ukrajině se rozhoduje o osudu Evropy a o naší vlastní bezpečnosti.  "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-49",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-50",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-50",
+      "answer": "yes",
+      "comment": "Vzhledem k nutnosti zajistit energetickou bezpečnost není možné spoléhat na to že nám elektřinu někdo dodá na klíč a zadarmo. V našem energetickém mixu se bez jaderné energetiky zatím neobejdeme. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-51",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-52",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-52",
+      "answer": "yes",
+      "comment": "Tibetský dalajláma je duchovní autorita a jako prezident bych se s ním chtěl setkat."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-53",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-53",
+      "answer": "yes",
+      "comment": "Pokud by totiž měl být na překážku nízký věk u soudců, pak by bylo třeba, aby se příslušným způsobem upravil zákon o soudech a soudcích. Není na prezidentovi, aby určoval věk, od kdy mohou být adepti jmenováni soudci. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-54",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-55",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-56",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-56",
+      "answer": "no",
+      "comment": "Prezident má za úkol reprezentovat stát navenek. Takže by měl umět prezentovat nejen postoje vlády, ale v případě, že je to vhodné, v duchu loajality a spolupráce s vládou připojit i své osobní hledisko.  "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-57",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-58",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-59",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-60",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-60",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-61",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-61",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-62",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-63",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-63",
+      "answer": "yes",
+      "comment": "Neměli bychom ale rezignovat na to, že i při obchodních vztazích je potřeba důležitost dodržování lidských práv připomínat"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-64",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-64",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-65",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-65",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-66",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-66",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-67",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-67",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-68",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-68",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-69",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-69",
+      "answer": "no",
+      "comment": "Svoboda akademického bádání umožňuje, aby to  byly vysoké školy, které vybírají a navrhují kandidáty na profesory. Návrhy podává ministr školství, který za ně také odpovídá. Pokud by prezident odmítal někoho jmenovat, mohlo by se jednat o porušení principu nezávislosti akademické svobody. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-70",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-70",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-71",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-71",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-72",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-72",
+      "answer": "no",
+      "comment": "Po ruské invazi v únoru 2022 to mělo svůj význam, ale nepovažuji to za nezbytné. Naopak za nezbytné považuji, abychom Ukrajině v jejím zápase účinně pomáhali."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-73",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-73",
+      "answer": "no",
+      "comment": "A pokud, pak ve výjimečném případě, což platí i pro další spojence ČR."
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-74",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-74",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-75",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-75",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-76",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-76",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-77",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-77",
+      "answer": "yes",
+      "comment": "Může tak činit vhodným způsobem a v souladu s diplomatickými zvyklostmi. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-78",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-78",
+      "answer": "yes",
+      "comment": "Úroveň především terénní péče je u nás dlouhodobě nedostatečná. Zlepšení psychiatrické a psychologické péče proto považuji za prioritu. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-79",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-79",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-80",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-80",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-81",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-81",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-82",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-82",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-83",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-83",
+      "answer": "no",
+      "comment": "Záměr je to chvályhodný, ale není jasné, jakým autem budou jezdit senioři nebo rodiny s malými dětmi do školy. Bez odpovídajícího rozvoje hromadné dopravy se může vysoká cena za nákup elektrického vozu nepřekonatelnou překážkou pro mnoho našich občanů. Bez odpovídající studie dopadů na jejich život by mohlo jít o rozhodnutí velmi nepromyšlené. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-84",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-84",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-85",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-85",
+      "answer": "yes",
+      "comment": "Prohlubovat spolupráci v oblastech, kde je to třeba, je zcela na místě. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-86",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-86",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-87",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-87",
+      "answer": "yes",
+      "comment": "Bez toho, že vytvoříme podmínky pro lepší ohodnocení žen-matek, nebo pro jejich návrat do práce po mateřské, se u nás nic nezmění. ČR je totiž v EU až na 16.místě z hlediska velikosti rozdílů hodnocení mezi muži a ženami. Nemusíme hned schvalovat novou legislativu. Docela stačí vyzdvihovat pozitivní příklady firem nebo úřadů, které jsou v tomto hodny následování. Jako prezident bych se tomu věnoval. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-88",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-88",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-89",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-89",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-90",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-90",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-91",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-91",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-92",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-92",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-93",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-93",
+      "answer": "yes",
+      "comment": "Ale především by prezident měl podporovat úsilí všech institucí, jejichž poslání je právě v boji s dezinformacemi. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-94",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-94",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-95",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-95",
+      "answer": "yes",
+      "comment": "Úkolem prezidenta je, aby u něj získali zastání všichni občané ČR bez rozdílu. "
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-96",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-96",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-97",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-97",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-1-global-a-291038-98",
+      "candidate_id": "prezidentske-2023-kolo-1-global-c-291038",
+      "question_id": "prezidentske-2023-kolo-1-global-q-98",
+      "answer": "yes"
     }
   ]
 }

--- a/data/kalkulacka/prezidentske-2023-kolo-test/global.json
+++ b/data/kalkulacka/prezidentske-2023-kolo-test/global.json
@@ -1,0 +1,219 @@
+{
+  "id": "prezidentske-2023-kolo-test-global",
+  "name": "global",
+  "description": "global",
+  "district_code": "global",
+  "show_district_code": true,
+  "election": {
+    "id": "prezidentske-2023-kolo-test",
+    "key": "prezidentske-2023-kolo-test",
+    "name": "Prezidentské volby 2023 - 1. kolo",
+    "description": "Letos se volí v prezidentských volbách.",
+    "instructions": {
+      "header": "Prezidentske - header",
+      "step_1_1": "",
+      "step_1_2": "",
+      "step_1_link": "",
+      "step_2_1": "Prezidentske - 2_2"
+    },
+    "from": "2023-01-13T14:00:00",
+    "to": "2023-01-14T14:00:00"
+  },
+  "questions": [
+    {
+      "id": "prezidentske-2023-kolo-test-global-q-4",
+      "name": "Rychlovlaky priorita",
+      "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
+      "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
+      "detail": "",
+      "tags": ["doprava"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-q-3",
+      "name": "Celostátní referendum",
+      "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
+      "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
+      "detail": "",
+      "tags": ["demokracie"]
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-q-1",
+      "name": "Zdanění prázdných bytů",
+      "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
+      "gist": "Zastánci zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
+      "detail": "",
+      "tags": ["bydlení"]
+    }
+  ],
+  "candidates": [
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-935631",
+      "name": "Petr Pavel",
+      "type": "person",
+      "description": "Petr Pavel",
+      "short_name": "Petr Pavel",
+      "is_active": false,
+      "given_name": "Petr",
+      "family_name": "Pavel",
+      "contacts": {
+        "web": []
+      },
+      "parties": []
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-904458",
+      "name": "Andrej Babiš",
+      "type": "person",
+      "description": "Andrej Babiš",
+      "short_name": "Andrej Babiš",
+      "is_active": false,
+      "given_name": "Andrej",
+      "family_name": "Babiš",
+      "contacts": {
+        "web": []
+      },
+      "parties": []
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-728980",
+      "name": "Danuše Nerudová",
+      "type": "person",
+      "description": "Danuše Nerudová",
+      "short_name": "Danuše Nerudová",
+      "is_active": false,
+      "given_name": "Danuše",
+      "family_name": "Nerudová",
+      "contacts": {
+        "web": []
+      },
+      "parties": []
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-784509",
+      "name": "Josef Středula",
+      "type": "person",
+      "description": "Josef Středula",
+      "short_name": "Josef Středula",
+      "is_active": false,
+      "given_name": "Josef",
+      "family_name": "Středula",
+      "contacts": {
+        "web": []
+      },
+      "parties": []
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-879071",
+      "name": "Marek Hilšer",
+      "type": "person",
+      "description": "Marek Hilšer",
+      "short_name": "Marek Hilšer",
+      "is_active": false,
+      "given_name": "Marek",
+      "family_name": "Hilšer",
+      "contacts": {
+        "web": []
+      },
+      "parties": []
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-291038",
+      "name": "Pavel Fischer",
+      "type": "person",
+      "description": "Pavel Fischer",
+      "short_name": "Pavel Fischer",
+      "is_active": false,
+      "given_name": "Pavel",
+      "family_name": "Fischer",
+      "contacts": {
+        "web": []
+      },
+      "parties": []
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-800655",
+      "name": "Jaroslav Bašta",
+      "type": "person",
+      "description": "Jaroslav Bašta",
+      "short_name": "Jaroslav Bašta",
+      "is_active": false,
+      "given_name": "Jaroslav",
+      "family_name": "Bašta",
+      "contacts": {
+        "web": []
+      },
+      "parties": [],
+      "motto": "SPD forever."
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-427663",
+      "name": "Tomáš Zima",
+      "type": "person",
+      "description": "Tomáš Zima",
+      "short_name": "Tomáš Zima",
+      "is_active": false,
+      "given_name": "Tomáš",
+      "family_name": "Zima",
+      "contacts": {
+        "web": []
+      },
+      "parties": []
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-c-497739",
+      "name": "Karel Diviš",
+      "type": "person",
+      "description": "Karel Diviš",
+      "short_name": "Karel Diviš",
+      "is_active": false,
+      "given_name": "Karel",
+      "family_name": "Diviš",
+      "contacts": {
+        "web": []
+      },
+      "parties": [],
+      "motto": "Jsem boží."
+    }
+  ],
+  "answers": [
+    {
+      "id": "prezidentske-2023-kolo-test-global-a-497739-4",
+      "candidate_id": "prezidentske-2023-kolo-test-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-test-global-q-4",
+      "answer": "yes",
+      "comment": "Yes, please."
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-a-497739-3",
+      "candidate_id": "prezidentske-2023-kolo-test-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-test-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-a-497739-1",
+      "candidate_id": "prezidentske-2023-kolo-test-global-c-497739",
+      "question_id": "prezidentske-2023-kolo-test-global-q-1",
+      "answer": "yes",
+      "comment": "Test only"
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-a-800655-4",
+      "candidate_id": "prezidentske-2023-kolo-test-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-test-global-q-4",
+      "answer": "dont_know"
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-a-800655-3",
+      "candidate_id": "prezidentske-2023-kolo-test-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-test-global-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "prezidentske-2023-kolo-test-global-a-800655-1",
+      "candidate_id": "prezidentske-2023-kolo-test-global-c-800655",
+      "question_id": "prezidentske-2023-kolo-test-global-q-1",
+      "answer": "no",
+      "comment": "SPD, SPD, co si počnem bez tebe."
+    }
+  ]
+}

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -53,7 +53,7 @@ poetry-run-api:
 	poetry run uvicorn main:app --reload --host $(API_HOST) --port $(API_PORT)
 
 poetry-run-converter:
-	poetry run ./converter.py
+	poetry run ./converter.py --wait 10
 
 poetry-run-enrich-with-pdv:
 	poetry run ./enrich_with_pdv.py

--- a/generator/converter.py
+++ b/generator/converter.py
@@ -22,6 +22,7 @@ EXTRACT = {
     "senatni-2022": extract_election_senatni,
     "komunalni-2022": extract_election_komunalni,
     "prezidentske-2023-kolo-1": extract_election_prezidentske,
+    "prezidentske-2023-kolo-test": extract_election_prezidentske,
 }  # type: Dict[str, C]
 
 
@@ -31,7 +32,7 @@ if __name__ == "__main__":
         "--wait",
         type=float,
         help="Wait the specified number of seconds between requests to Google Sheet",
-        default=5.0,
+        default=10.0,
     )
     parser.add_argument(
         "--doc-key",

--- a/generator/generator/prezidentske_2023.py
+++ b/generator/generator/prezidentske_2023.py
@@ -67,7 +67,7 @@ def extract_election_prezidentske(
 
     # load file
     doc_questions = gc.open_by_key(key_questions)
-    sheet_questions = doc_questions.worksheet("OTÁZKY")
+    sheet_questions = doc_questions.worksheet("Sheet1")
 
     question_definitions = extract_prezidentske_question_definitions(
         sheet_questions,
@@ -131,8 +131,8 @@ def extract_prezidentske_question_definitions(
             name="name",
             title="question",
             gist="description",
-            detail="note",
-            tags="téma",
+            detail="name eng",
+            tags="tags",
             order="order",
         ),
     )


### PR DESCRIPTION
Vygenerovana data: `make run-generate-data`

Zmeny proti testovacim datum:
* Dokument otazky
  * sheet se jmenuje Sheet1, i kdyz se u zkusebniho souboru jmenoval OTÁZKY, u Senatnich se taky jmenoval Sheet1 => prejmenoval jsem sheet v testovacim souboru + upravil kod
  * Testovaci ma sloupecek téma, ostrý má sloupeček tags => upravil jsem testovaci sheet + upravil jsem kod
  * Testovaci ma sloupecek note, ktery se dava do atributu detail. Ostry zadny takovy sloupecek nema => dal jsem tam name eng

Je zajimave, ze je tam 100 otazek
