### PR TITLE
Add subscribe to API

### DIFF
--- a/frontend/api/subscriptions/index.ts
+++ b/frontend/api/subscriptions/index.ts
@@ -1,0 +1,33 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+import { prisma } from '../../src/server/prisma';
+import { respond401, respond405 } from '../../src/server/errors';
+
+export default async function (req: VercelRequest, res: VercelResponse) {
+  if (req.method === 'POST') {
+    const { email } = req.body;
+
+    if (!email) {
+      return respond401(res, 'Email is required.');
+    }
+
+    const existingUser = await prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (existingUser) {
+      return respond401(res);
+    }
+
+    const user = await prisma.user.create({
+      data: {
+        email,
+        subscribed: true,
+      },
+    });
+
+    return res.status(201).json(user);
+  } else {
+    return respond405(res, req.method);
+  }
+}

--- a/frontend/prisma/migrations/20230720085340_add_subscribed_to_user/migration.sql
+++ b/frontend/prisma/migrations/20230720085340_add_subscribed_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "subscribed" BOOL NOT NULL DEFAULT false;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   id             String    @id @default(uuid())
   displayName    String?   @db.String(255)
   email          String?   @unique @db.String(255)
+  subscribed     Boolean   @default(false)
   authProvider   String?   @db.String(32)
   authProviderId String?   @unique @db.String(255)
   createdAt      DateTime  @default(now()) @db.Timestamptz()


### PR DESCRIPTION
Adds new `POST /subscriptions` endpoint with the following payload:

```json
{
  "email": "your@email.address"
}
```

which creates a new row in users table with subscription attribute flagged as true.

No authentication needed. If user with such email already exists, error 401 Unauthorized is returned.