### PR TITLE
Add time attributes to schemas

### DIFF
--- a/data/example/volebnikalkulacka.cz/doprava-v-praze/calculator.json
+++ b/data/example/volebnikalkulacka.cz/doprava-v-praze/calculator.json
@@ -1,4 +1,5 @@
 {
   "id": "a6dd323c-d0b4-4d3b-bdbe-e6942c4c4f94",
-  "key": "doprava-v-praze"
+  "key": "doprava-v-praze",
+  "createdAt": "2021-01-01T00:00:00+01:00"
 }

--- a/data/example/volebnikalkulacka.cz/green-deal/calculator-group.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/calculator-group.json
@@ -1,6 +1,7 @@
 {
   "id": "60c47450-3282-4c59-9be7-3ee532bc4605",
   "key": "green-deal",
+  "createdAt": "2021-01-01T00:00:00+01:00",
   "variants": [
     {
       "key": "pro-kazdeho"

--- a/data/example/volebnikalkulacka.cz/green-deal/pro-experty/calculator.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/pro-experty/calculator.json
@@ -1,5 +1,6 @@
 {
   "id": "a76be715-16a8-4cc2-9d98-ad50075e2d74",
+  "createdAt": "2021-01-01T00:00:00+01:00",
   "calculatorGroup": {
     "id": "60c47450-3282-4c59-9be7-3ee532bc4605",
     "key": "green-deal"

--- a/data/example/volebnikalkulacka.cz/green-deal/pro-kazdeho/calculator.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/pro-kazdeho/calculator.json
@@ -1,5 +1,6 @@
 {
   "id": "5ecaed42-a224-4a8d-aa39-23dcf9132dfe",
+  "createdAt": "2021-01-01T00:00:00+01:00",
   "calculatorGroup": {
     "id": "60c47450-3282-4c59-9be7-3ee532bc4605",
     "key": "green-deal"

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/1-kolo/calculator.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/1-kolo/calculator.json
@@ -1,5 +1,6 @@
 {
   "id": "fdd4cb21-3ef2-40df-bcfa-e559fd650490",
+  "createdAt": "2021-01-01T00:00:00+01:00",
   "calculatorGroup": {
     "id": "adc1c133-8128-41d0-b841-e7b51175bb5c",
     "key": "prezidentske-2023"

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/2-kolo/calculator.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/2-kolo/calculator.json
@@ -1,5 +1,6 @@
 {
   "id": "84599cb4-3ae5-4756-b724-80e282e95dca",
+  "createdAt": "2021-01-01T00:00:00+01:00",
   "calculatorGroup": {
     "id": "adc1c133-8128-41d0-b841-e7b51175bb5c",
     "key": "prezidentske-2023"

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/calculator-group.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/calculator-group.json
@@ -1,6 +1,7 @@
 {
   "id": "adc1c133-8128-41d0-b841-e7b51175bb5c",
   "key": "prezidentske-2023",
+  "createdAt": "2021-01-01T00:00:00+01:00",
   "election": {
     "id": "42c891d6-dd8a-48ef-b724-8e9d17348ecf",
     "key": "prezidentske-2023"

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/election.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/election.json
@@ -1,6 +1,7 @@
 {
   "id": "42c891d6-dd8a-48ef-b724-8e9d17348ecf",
   "key": "prezidentske-2023",
+  "createdAt": "2021-01-01T00:00:00+01:00",
   "calculatorGroup": {
     "id": "adc1c133-8128-41d0-b841-e7b51175bb5c",
     "key": "prezidentske-2023"

--- a/data/schemas/calculator-group.schema.json
+++ b/data/schemas/calculator-group.schema.json
@@ -19,6 +19,27 @@
       "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
       "examples": ["prezidentske-2023"]
     },
+    "createdAt": {
+      "title": "Created at",
+      "description": "Time of the creation of a calculator group in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
+    "updatedAt": {
+      "title": "Updated at",
+      "description": "Time of the last update of a calculator group in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
+    "publishedAt": {
+      "title": "Published at",
+      "description": "Time when a calculator group should be published in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
     "election": {
       "title": "Election",
       "description": "Reference to an election the calculator belongs to",
@@ -60,10 +81,19 @@
     },
     "variants": {
       "$ref": "#/$defs/variants"
+    },
+    "createdAt": {
+      "$ref": "#/$defs/createdAt"
+    },
+    "updatedAt": {
+      "$ref": "#/$defs/updatedAt"
+    },
+    "publishedAt": {
+      "$ref": "#/$defs/publishedAt"
     }
   },
   "unevaluatedProperties": false,
-  "required": ["id", "key"],
+  "required": ["id", "key", "createdAt"],
   "oneOf": [
     {
       "properties": {

--- a/data/schemas/calculator.schema.json
+++ b/data/schemas/calculator.schema.json
@@ -19,6 +19,27 @@
       "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
       "examples": ["doprava-v-praze"]
     },
+    "createdAt": {
+      "title": "Created at",
+      "description": "Time of the creation of a calculator in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
+    "updatedAt": {
+      "title": "Updated at",
+      "description": "Time of the last update of a calculator in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
+    "publishedAt": {
+      "title": "Published at",
+      "description": "Time when a calculator should be published in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
     "calculatorGroup": {
       "title": "Calculator group",
       "description": "Reference to a calculator group the calculator belongs to",
@@ -83,10 +104,19 @@
   "properties": {
     "id": {
       "$ref": "#/$defs/id"
+    },
+    "createdAt": {
+      "$ref": "#/$defs/createdAt"
+    },
+    "updatedAt": {
+      "$ref": "#/$defs/updatedAt"
+    },
+    "publishedAt": {
+      "$ref": "#/$defs/publishedAt"
     }
   },
   "unevaluatedProperties": false,
-  "required": ["id"],
+  "required": ["id", "createdAt"],
   "oneOf": [
     {
       "title": "Standalone calculator",

--- a/data/schemas/election.schema.json
+++ b/data/schemas/election.schema.json
@@ -19,6 +19,27 @@
       "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
       "examples": ["prezidentske-2023"]
     },
+    "createdAt": {
+      "title": "Created at",
+      "description": "Time of the creation of an election in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
+    "updatedAt": {
+      "title": "Updated at",
+      "description": "Time of the last update of an election group in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
+    "publishedAt": {
+      "title": "Published at",
+      "description": "Time when an election group should be published in the ISO 8601 format",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2021-01-01T00:00:00+01:00"]
+    },
     "calculatorGroup": {
       "title": "Calculator group",
       "description": "Reference to a calculator group with election calculators",
@@ -42,6 +63,15 @@
     "key": {
       "$ref": "#/$defs/key"
     },
+    "createdAt": {
+      "$ref": "#/$defs/createdAt"
+    },
+    "updatedAt": {
+      "$ref": "#/$defs/updatedAt"
+    },
+    "publishedAt": {
+      "$ref": "#/$defs/publishedAt"
+    },
     "calculatorGroup": {
       "$ref": "#/$defs/calculatorGroup"
     },
@@ -62,5 +92,5 @@
       }
     }
   },
-  "required": ["id", "key", "calculatorGroup"]
+  "required": ["id", "key", "createdAt", "calculatorGroup"]
 }


### PR DESCRIPTION
Adds `createdAt`, `updatedAt` and `publishedAt` attributes to calculators, calculator groups and elections.

`createdAt` is required, `updatedAt` should be added when an existing calculator/group/election was updated and `publishedAt` when it should be published on the website; if not present, the calculator will be hidden from the public.