### PR TITLE
Add names to schemas

### DIFF
--- a/data/example/volebnikalkulacka.cz/doprava-v-praze/calculator.json
+++ b/data/example/volebnikalkulacka.cz/doprava-v-praze/calculator.json
@@ -1,5 +1,7 @@
 {
   "id": "a6dd323c-d0b4-4d3b-bdbe-e6942c4c4f94",
   "key": "doprava-v-praze",
+  "title": "Dopravní situace a parkování v Praze",
+  "shortTitle": "Doprava v Praze",
   "createdAt": "2021-01-01T00:00:00+01:00"
 }

--- a/data/example/volebnikalkulacka.cz/doprava-v-praze/organizations.json
+++ b/data/example/volebnikalkulacka.cz/doprava-v-praze/organizations.json
@@ -1,11 +1,13 @@
 [
   {
     "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",
-    "name": "Česká republika"
+    "name": "Česká republika",
+    "shortName": "Česko"
   },
   {
     "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4",
-    "name": "NATO",
+    "name": "Severoatlantická aliance",
+    "abbreviation": "NATO",
     "members": [
       {
         "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",

--- a/data/example/volebnikalkulacka.cz/doprava-v-praze/persons.json
+++ b/data/example/volebnikalkulacka.cz/doprava-v-praze/persons.json
@@ -2,6 +2,8 @@
   {
     "id": "5ee570e9-fdc6-4af1-8af5-a5e5589c44a6",
     "name": "Petr Pavel",
+    "familyName": "Pavel",
+    "givenName": "Petr",
     "memberOf": [
       {
         "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4"

--- a/data/example/volebnikalkulacka.cz/green-deal/calculator-group.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/calculator-group.json
@@ -2,6 +2,8 @@
   "id": "60c47450-3282-4c59-9be7-3ee532bc4605",
   "key": "green-deal",
   "createdAt": "2021-01-01T00:00:00+01:00",
+  "title": "Green deal a další opatření na ochranu klimatu",
+  "shortTitle": "Green deal",
   "variants": [
     {
       "key": "pro-kazdeho"

--- a/data/example/volebnikalkulacka.cz/green-deal/pro-experty/organizations.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/pro-experty/organizations.json
@@ -1,11 +1,13 @@
 [
   {
     "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",
-    "name": "Česká republika"
+    "name": "Česká republika",
+    "shortName": "Česko"
   },
   {
     "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4",
-    "name": "NATO",
+    "name": "Severoatlantická aliance",
+    "abbreviation": "NATO",
     "members": [
       {
         "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",

--- a/data/example/volebnikalkulacka.cz/green-deal/pro-experty/persons.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/pro-experty/persons.json
@@ -2,6 +2,8 @@
   {
     "id": "5ee570e9-fdc6-4af1-8af5-a5e5589c44a6",
     "name": "Petr Pavel",
+    "familyName": "Pavel",
+    "givenName": "Petr",
     "memberOf": [
       {
         "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4"

--- a/data/example/volebnikalkulacka.cz/green-deal/pro-kazdeho/organizations.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/pro-kazdeho/organizations.json
@@ -1,11 +1,13 @@
 [
   {
     "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",
-    "name": "Česká republika"
+    "name": "Česká republika",
+    "shortName": "Česko"
   },
   {
     "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4",
-    "name": "NATO",
+    "name": "Severoatlantická aliance",
+    "abbreviation": "NATO",
     "members": [
       {
         "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",

--- a/data/example/volebnikalkulacka.cz/green-deal/pro-kazdeho/persons.json
+++ b/data/example/volebnikalkulacka.cz/green-deal/pro-kazdeho/persons.json
@@ -2,6 +2,8 @@
   {
     "id": "5ee570e9-fdc6-4af1-8af5-a5e5589c44a6",
     "name": "Petr Pavel",
+    "familyName": "Pavel",
+    "givenName": "Petr",
     "memberOf": [
       {
         "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4"

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/1-kolo/organizations.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/1-kolo/organizations.json
@@ -1,11 +1,13 @@
 [
   {
     "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",
-    "name": "Česká republika"
+    "name": "Česká republika",
+    "shortName": "Česko"
   },
   {
     "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4",
-    "name": "NATO",
+    "name": "Severoatlantická aliance",
+    "abbreviation": "NATO",
     "members": [
       {
         "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/1-kolo/persons.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/1-kolo/persons.json
@@ -2,6 +2,8 @@
   {
     "id": "5ee570e9-fdc6-4af1-8af5-a5e5589c44a6",
     "name": "Petr Pavel",
+    "familyName": "Pavel",
+    "givenName": "Petr",
     "memberOf": [
       {
         "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4"

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/2-kolo/organizations.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/2-kolo/organizations.json
@@ -1,11 +1,13 @@
 [
   {
     "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",
-    "name": "Česká republika"
+    "name": "Česká republika",
+    "shortName": "Česko"
   },
   {
     "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4",
-    "name": "NATO",
+    "name": "Severoatlantická aliance",
+    "abbreviation": "NATO",
     "members": [
       {
         "id": "536fba26-bf7e-4e95-97fe-55157eed43fe",

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/2-kolo/persons.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/2-kolo/persons.json
@@ -2,6 +2,8 @@
   {
     "id": "5ee570e9-fdc6-4af1-8af5-a5e5589c44a6",
     "name": "Petr Pavel",
+    "familyName": "Pavel",
+    "givenName": "Petr",
     "memberOf": [
       {
         "id": "5fb7d561-6e93-45c2-9c75-6a1f2b11deb4"

--- a/data/example/volebnikalkulacka.cz/prezidentske-2023/election.json
+++ b/data/example/volebnikalkulacka.cz/prezidentske-2023/election.json
@@ -2,6 +2,8 @@
   "id": "42c891d6-dd8a-48ef-b724-8e9d17348ecf",
   "key": "prezidentske-2023",
   "createdAt": "2021-01-01T00:00:00+01:00",
+  "title": "Prezidentské volby 2023",
+  "shortTitle": "Prezidentské 2023",
   "calculatorGroup": {
     "id": "adc1c133-8128-41d0-b841-e7b51175bb5c",
     "key": "prezidentske-2023"

--- a/data/schemas/calculator-group.schema.json
+++ b/data/schemas/calculator-group.schema.json
@@ -40,6 +40,25 @@
       "format": "date-time",
       "examples": ["2021-01-01T00:00:00+01:00"]
     },
+    "title": {
+      "title": "Title",
+      "description": "Title of a calculator group",
+      "type": "string",
+      "examples": ["Prezidentské volby 2023"]
+    },
+    "shortTitle": {
+      "title": "shortTitle",
+      "description": "Short title of a calculator group with a maximum of 25 characters",
+      "type": "string",
+      "maxLength": 25,
+      "examples": ["Prezidentské 2023"]
+    },
+    "description": {
+      "title": "Description",
+      "description": "Description of a calculator group",
+      "type": "string",
+      "examples": ["Volební kalkulačky pro obě kola prezidentských voleb 2023"]
+    },
     "election": {
       "title": "Election",
       "description": "Reference to an election the calculator belongs to",
@@ -90,6 +109,15 @@
     },
     "publishedAt": {
       "$ref": "#/$defs/publishedAt"
+    },
+    "title": {
+      "$ref": "#/$defs/title"
+    },
+    "shortTitle": {
+      "$ref": "#/$defs/shortTitle"
+    },
+    "description": {
+      "$ref": "#/$defs/description"
     }
   },
   "unevaluatedProperties": false,
@@ -117,7 +145,7 @@
           }
         }
       },
-      "required": ["calculators"]
+      "required": ["title", "shortTitle", "calculators"]
     },
     {
       "properties": {

--- a/data/schemas/calculator.schema.json
+++ b/data/schemas/calculator.schema.json
@@ -40,6 +40,25 @@
       "format": "date-time",
       "examples": ["2021-01-01T00:00:00+01:00"]
     },
+    "title": {
+      "title": "Title",
+      "description": "Title of a calculator",
+      "type": "string",
+      "examples": ["2. kolo prezidentských voleb 2023"]
+    },
+    "shortTitle": {
+      "title": "shortTitle",
+      "description": "Short title of a calculator with a maximum of 25 characters",
+      "type": "string",
+      "maxLength": 25,
+      "examples": ["Prezidentské (2. kolo)"]
+    },
+    "description": {
+      "title": "Description",
+      "description": "Description of a calculator",
+      "type": "string",
+      "examples": ["Volební kalkulačka pro 2. kolo prezidentských voleb 2023"]
+    },
     "calculatorGroup": {
       "title": "Calculator group",
       "description": "Reference to a calculator group the calculator belongs to",
@@ -113,6 +132,15 @@
     },
     "publishedAt": {
       "$ref": "#/$defs/publishedAt"
+    },
+    "title": {
+      "$ref": "#/$defs/title"
+    },
+    "shortTitle": {
+      "$ref": "#/$defs/shortTitle"
+    },
+    "description": {
+      "$ref": "#/$defs/description"
     }
   },
   "unevaluatedProperties": false,
@@ -126,7 +154,7 @@
           "$ref": "#/$defs/key"
         }
       },
-      "required": ["key"]
+      "required": ["key", "title", "shortTitle"]
     },
     {
       "title": "Calculator from a group",

--- a/data/schemas/election.schema.json
+++ b/data/schemas/election.schema.json
@@ -40,6 +40,25 @@
       "format": "date-time",
       "examples": ["2021-01-01T00:00:00+01:00"]
     },
+    "title": {
+      "title": "Title",
+      "description": "Title of an election",
+      "type": "string",
+      "examples": ["Prezidentské volby 2023"]
+    },
+    "shortTitle": {
+      "title": "shortTitle",
+      "description": "Short title of an election with a maximum of 25 characters",
+      "type": "string",
+      "maxLength": 25,
+      "examples": ["Prezidentské 2023"]
+    },
+    "description": {
+      "title": "Description",
+      "description": "Description of an election",
+      "type": "string",
+      "examples": ["Volební kalkulačky pro obě kola prezidentských voleb 2023"]
+    },
     "calculatorGroup": {
       "title": "Calculator group",
       "description": "Reference to a calculator group with election calculators",
@@ -72,6 +91,15 @@
     "publishedAt": {
       "$ref": "#/$defs/publishedAt"
     },
+    "title": {
+      "$ref": "#/$defs/title"
+    },
+    "shortTitle": {
+      "$ref": "#/$defs/shortTitle"
+    },
+    "description": {
+      "$ref": "#/$defs/description"
+    },
     "calculatorGroup": {
       "$ref": "#/$defs/calculatorGroup"
     },
@@ -92,5 +120,12 @@
       }
     }
   },
-  "required": ["id", "key", "createdAt", "calculatorGroup"]
+  "required": [
+    "id",
+    "key",
+    "createdAt",
+    "title",
+    "shortTitle",
+    "calculatorGroup"
+  ]
 }

--- a/data/schemas/organization.schema.json
+++ b/data/schemas/organization.schema.json
@@ -51,6 +51,34 @@
       "description": "Organization's preferred full name",
       "type": "string"
     },
+    "officialName": {
+      "title": "Short name",
+      "description": "Organization's official name with an unlimited length",
+      "type": "string"
+    },
+    "shortName": {
+      "title": "Short name",
+      "description": "Organization's short name with max. 25 characters",
+      "maxLength": 25,
+      "type": "string"
+    },
+    "abbreviation": {
+      "title": "Abbreviation",
+      "description": "Organization's abbreviation with max. 15 characters",
+      "maxLength": 15,
+      "type": "string"
+    },
+    "sortName": {
+      "description": "A name to use in a lexicographically ordered list",
+      "type": "string"
+    },
+    "alternateNames": {
+      "description": "Alternate names to use for example in search",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "members": {
       "title": "Members",
       "description": "List of members of an organization",
@@ -69,5 +97,13 @@
     }
   },
   "unevaluatedProperties": false,
-  "required": ["id", "name"]
+  "required": ["id", "name"],
+  "anyOf": [
+    {
+      "required": ["shortName"]
+    },
+    {
+      "required": ["abbreviation"]
+    }
+  ]
 }

--- a/data/schemas/person.schema.json
+++ b/data/schemas/person.schema.json
@@ -17,6 +17,37 @@
       "description": "Person's preferred full name",
       "type": "string"
     },
+    "familyName": {
+      "description": "Family name (last name)",
+      "type": "string"
+    },
+    "givenName": {
+      "description": "Given name (first name)",
+      "type": "string"
+    },
+    "additionalName": {
+      "description": "Additional name (middle name)",
+      "type": "string"
+    },
+    "honorificPrefix": {
+      "description": "Honorifics preceding a person's name",
+      "type": "string"
+    },
+    "honorificSuffix": {
+      "description": "Honorifics following a person's name",
+      "type": "string"
+    },
+    "sortName": {
+      "description": "A name to use in a lexicographically ordered list",
+      "type": "string"
+    },
+    "alternateNames": {
+      "description": "Alternate names to use for example in search",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "memberOf": {
       "title": "Member of",
       "description": "List of organizations a person is a member of",
@@ -37,5 +68,13 @@
     }
   },
   "unevaluatedProperties": false,
-  "required": ["id", "name"]
+  "required": ["id"],
+  "anyOf": [
+    {
+      "required": ["name"]
+    },
+    {
+      "required": ["familyName", "givenName"]
+    }
+  ]
 }


### PR DESCRIPTION
Adds names and titles to schemas:
- for person either `fullName` or both `givenName` and `familyName` is required
- for organization `name` and either `shortName` or `abbreviation` is required
- `title`, `shortTitle` (required) and `description` is inherited via election → calculator group → calculator (for example it is required only for standalone calculator)
