### PR TITLE
Aktualizace Ubuntu v GitHub Actions

### DIFF
--- a/.github/workflows/backend-deploy.yaml
+++ b/.github/workflows/backend-deploy.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   deploy:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v1


### PR DESCRIPTION
Martin Venyš narazil na to, že GitHub ukončil podporu Ubuntu 18.04 ([diskuze tady](https://cesko-digital.slack.com/archives/CS7RPPVUL/p1693472609029919)), tak můžem přehodit na `ubuntu-latest`?